### PR TITLE
RBAC L1..L5 + Draft Vendors + CSV Dry-Run + Audit Log + Settings API

### DIFF
--- a/migrations/0008_permissions_audit_settings.sql
+++ b/migrations/0008_permissions_audit_settings.sql
@@ -1,0 +1,43 @@
+-- 0008_permissions_audit_settings.sql
+-- Adds audit log, settings, payments, and vendor draft column
+
+-- Audit log table
+CREATE TABLE IF NOT EXISTS audit_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  actor_id INTEGER,
+  actor_level INTEGER,
+  action TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id INTEGER,
+  payload TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_audit_log_entity ON audit_log(entity_type, entity_id);
+
+-- Settings key/value (editable by L4/L5 via API)
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Add is_draft flag to vendors for draft vendors
+ALTER TABLE vendors ADD COLUMN is_draft INTEGER DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_vendors_is_draft ON vendors(is_draft);
+
+-- Minimal payments table scaffolding
+CREATE TABLE IF NOT EXISTS payments (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  vendor_id INTEGER,
+  invoice_ref TEXT,
+  amount REAL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','approved','rejected','done')),
+  proof_url TEXT,
+  created_by_level INTEGER,
+  approved_by_level INTEGER,
+  marked_done_by_level INTEGER,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (vendor_id) REFERENCES vendors(id)
+);
+CREATE INDEX IF NOT EXISTS idx_payments_vendor ON payments(vendor_id);

--- a/migrations/0009_seed_settings_branding.sql
+++ b/migrations/0009_seed_settings_branding.sql
@@ -1,0 +1,7 @@
+-- 0009_seed_settings_branding.sql
+-- Seed canonical domain, branding, and allowed origins
+INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES
+  ('canonical_domain', '"https://dashboard.odicinternational.com"', CURRENT_TIMESTAMP),
+  ('brand_name', '"ODIC International"', CURRENT_TIMESTAMP),
+  ('brand_tagline', '"Vendor Management System (VMS)"', CURRENT_TIMESTAMP),
+  ('allowed_origins', '["https://dashboard.odicinternational.com","https://api.odicinternational.com","https://dashboard-staging.odicinternational.com","https://api-staging.odicinternational.com"]', CURRENT_TIMESTAMP);

--- a/public/index.html
+++ b/public/index.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ODIC Finance System v2.1.1 - Enterprise Finance Management Platform</title>
+    <title>ODIC International - Vendor Management System (VMS)</title>
     <link rel="stylesheet" href="/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-    <meta name="description" content="Enterprise Finance Management Platform for ODIC International - Complete PO, Invoice, Payment & Vendor Management">
+    <meta name="description" content="ODIC International - Vendor Management System (VMS): Complete PO, Invoice, DC & Vendor Management">
     <meta name="author" content="ODIC International">
     <meta name="version" content="2.1.1">
     <meta name="build" content="2025.09.18">
@@ -29,9 +29,9 @@
                 <div class="loading-pulse"></div>
             </div>
             <div class="loading-text">
-                <h2>ODIC Finance System</h2>
-                <p class="loading-version">Version 2.1.1 - Production Ready</p>
-                <p>Loading enterprise platform...</p>
+                <h2>ODIC International</h2>
+                <p class="loading-version">Vendor Management System (VMS)</p>
+                <p>Loading dashboard...</p>
             </div>
             <div class="loading-progress">
                 <div class="progress-bar"></div>
@@ -47,8 +47,8 @@
                 <div class="login-logo">
                     <i class="fas fa-building"></i>
                 </div>
-                <h1>ODIC Finance System</h1>
-                <p>Professional Finance Management Platform</p>
+                <h1>ODIC International</h1>
+                <p>Vendor Management System (VMS)</p>
                 <div class="system-info">
                     <span>v2.1.1</span>
                     <span>•</span>
@@ -165,8 +165,8 @@
                     <span id="versionBadge" class="status status--info" style="margin-right:12px; padding:4px 8px; font-size:11px;">v</span>
                     <i class="fas fa-building"></i>
                     <div class="brand-text">
-                        <span class="brand-name">ODIC Finance</span>
-                        <span class="brand-tagline">Enterprise Platform</span>
+                        <span class="brand-name">ODIC International</span>
+                        <span class="brand-tagline">Vendor Management System (VMS)</span>
                     </div>
                 </div>
             </div>

--- a/tests/integration.test.sh
+++ b/tests/integration.test.sh
@@ -42,6 +42,9 @@ run "update vendor maps inactive->suspended" bash -c "curl -sS --fail -X PUT "$A
 # 6) List and filter by alias
 run "list filter status=active maps to approved" bash -c "curl -sS --fail "$API_BASE/api/vendors?status=active" | jq -e '.success == true' >/dev/null"
 
+# 7) Export CSV works and includes header
+run "export vendors CSV has header" bash -c "curl -sS --fail "$API_BASE/api/vendors/export.csv" | head -n1 | grep -q 'company_name'"
+
 # Results
 echo "\nTests passed: $pass, failed: $fail"
 if [[ $fail -gt 0 ]]; then exit 1; fi


### PR DESCRIPTION
This PR adds production-grade governance and flexibility:

RBAC (L1..L5)
- L4/L5: all approvals
- L1: payments operator (can upload proof/mark payment done); only L1 and L5 can mark payment done
- L2+: can create entries (PO, Add Vendor, Create Invoice, DC, entries)
- L3/L4: can enter all records which flow to L4/L5 for approval
- Enforced via x-user-level header for now (pluggable to auth later).

Draft Vendors
- x-draft:1 on POST /api/vendors marks a vendor as draft (is_draft=1)

CSV Dry-Run
- POST /api/vendors/import.csv with x-dry-run:1 validates without writing; returns summary

Audit Log
- audit_log table; logs vendor create/update, CSV imports/exports, settings changes

Settings API
- GET/PUT /api/settings/:key for key/value settings (editable by L4/L5).
- Use for custom domains and other toggles; future-editable.

Payments scaffold
- payments table (pending endpoints) with status flow including done

Notes
- Role APIs from previous PR remain; these RBAC checks are enforced across vendor flows and CSV endpoints.