### PR TITLE
UI: Add Import templates links + CSV examples for Vendors/Instruments/PO/Invoice/DC

### DIFF
--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -18,6 +18,7 @@ function toJSON(fd){var o={};fd.forEach(function(v,k){if(o[k]!==undefined){if(Ar
 function pathOf(u){try{return new URL(u,location.href).pathname;}catch(e){return "";}}
 function isApiPath(p){return typeof p==="string" && p.indexOf("/api/")===0;}
     function isKnownJsonPath(p){return /^(\/api\/(vendors|payments|instruments|pos|invoices|dcs))(\/|$|$)/.test(p);} 
+    function isCsvImportPath(p){return /^\/api\/(vendors|payments|instruments|pos|invoices|dcs)\/import\.csv$/.test(p);} 
 function rewrite(u){try{var U=new URL(u,location.href);var baseH=new URL(BASE).host;var h=U.host; if(isApiPath(U.pathname)){ if(h!==baseH && (h.indexOf("odicinternational.com")!==-1 || h.indexOf("workers.dev")!==-1)){ return BASE+U.pathname+U.search; } if(h===location.host){ return BASE+U.pathname+U.search; } } return U.href; }catch(e){ if(typeof u==="string"){ if(u.indexOf("/api/")===0) return BASE+u; if(u.indexOf("api/")===0) return BASE+"/"+u; } return u; }}
 (function(){
   var __origFetch=window.fetch;
@@ -26,7 +27,7 @@ function rewrite(u){try{var U=new URL(u,location.href);var baseH=new URL(BASE).h
   async function __handleBodyForVendors(url,method,headers,body){
     try{
       var p=pathOf(url);
-      if(!isKnownJsonPath(p))return {headers:headers,body:body};
+      if(!isKnownJsonPath(p) || isCsvImportPath(p))return {headers:headers,body:body};
       if(method!=="POST"&&method!=="PUT")return {headers:headers,body:body};
       if(body&&typeof FormData!=="undefined"&&body instanceof FormData){headers.set("Content-Type","application/json");return {headers:headers,body:JSON.stringify(__toObj(body))};}
       if(body&&typeof URLSearchParams!=="undefined"&&body instanceof URLSearchParams){headers.set("Content-Type","application/json");return {headers:headers,body:JSON.stringify(Object.fromEntries(body))};}

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -17,6 +17,7 @@ try{var m=document.querySelector("meta[name=\"api-base-url\"]");if(m){m.setAttri
 function toJSON(fd){var o={};fd.forEach(function(v,k){if(o[k]!==undefined){if(Array.isArray(o[k]))o[k].push(v);else o[k]=[o[k],v];}else{o[k]=v;}});return o;}
 function pathOf(u){try{return new URL(u,location.href).pathname;}catch(e){return "";}}
 function isApiPath(p){return typeof p==="string" && p.indexOf("/api/")===0;}
+    function isKnownJsonPath(p){return /^(\/api\/(vendors|payments|instruments|pos|invoices|dcs))(\/|$|$)/.test(p);} 
 function rewrite(u){try{var U=new URL(u,location.href);var baseH=new URL(BASE).host;var h=U.host; if(isApiPath(U.pathname)){ if(h!==baseH && (h.indexOf("odicinternational.com")!==-1 || h.indexOf("workers.dev")!==-1)){ return BASE+U.pathname+U.search; } if(h===location.host){ return BASE+U.pathname+U.search; } } return U.href; }catch(e){ if(typeof u==="string"){ if(u.indexOf("/api/")===0) return BASE+u; if(u.indexOf("api/")===0) return BASE+"/"+u; } return u; }}
 (function(){
   var __origFetch=window.fetch;
@@ -25,7 +26,7 @@ function rewrite(u){try{var U=new URL(u,location.href);var baseH=new URL(BASE).h
   async function __handleBodyForVendors(url,method,headers,body){
     try{
       var p=pathOf(url);
-      if(!__isVendorPath(p))return {headers:headers,body:body};
+      if(!isKnownJsonPath(p))return {headers:headers,body:body};
       if(method!=="POST"&&method!=="PUT")return {headers:headers,body:body};
       if(body&&typeof FormData!=="undefined"&&body instanceof FormData){headers.set("Content-Type","application/json");return {headers:headers,body:JSON.stringify(__toObj(body))};}
       if(body&&typeof URLSearchParams!=="undefined"&&body instanceof URLSearchParams){headers.set("Content-Type","application/json");return {headers:headers,body:JSON.stringify(Object.fromEntries(body))};}

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -23,9 +23,14 @@ export async function onRequest(context) {
 
     const isVendorsEndpoint = /^vendors(\b|\/)/.test(pathAfterApi);
     const isRolesEndpoint = /^roles(\b|\/)/.test(pathAfterApi);
+    const isPaymentsEndpoint = /^payments(\b|\/)/.test(pathAfterApi);
+    const isInstrumentsEndpoint = /^instruments(\b|\/)/.test(pathAfterApi);
+    const isPOEndpoint = /^(pos|purchase_orders?)(\b|\/)/.test(pathAfterApi);
+    const isInvoicesEndpoint = /^invoices(\b|\/)/.test(pathAfterApi);
+    const isDCEndpoint = /^(dcs|delivery_challans?)(\b|\/)/.test(pathAfterApi);
     const isMutating = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
 
-    if (isMutating && (isVendorsEndpoint || isRolesEndpoint)) {
+    if (isMutating && (isVendorsEndpoint || isRolesEndpoint || isPaymentsEndpoint || isInstrumentsEndpoint || isPOEndpoint || isInvoicesEndpoint || isDCEndpoint)) {
       try {
         if (contentType.indexOf('multipart/form-data') !== -1) {
           const fd = await request.formData();

--- a/functions/api/[[path]].js
+++ b/functions/api/[[path]].js
@@ -30,7 +30,8 @@ export async function onRequest(context) {
     const isDCEndpoint = /^(dcs|delivery_challans?)(\b|\/)/.test(pathAfterApi);
     const isMutating = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
 
-    if (isMutating && (isVendorsEndpoint || isRolesEndpoint || isPaymentsEndpoint || isInstrumentsEndpoint || isPOEndpoint || isInvoicesEndpoint || isDCEndpoint)) {
+    const isCsvImport = /^(vendors|payments|instruments|pos|invoices|dcs)\/import\.csv$/.test(pathAfterApi);
+    if (isMutating && !isCsvImport && (isVendorsEndpoint || isRolesEndpoint || isPaymentsEndpoint || isInstrumentsEndpoint || isPOEndpoint || isInvoicesEndpoint || isDCEndpoint)) {
       try {
         if (contentType.indexOf('multipart/form-data') !== -1) {
           const fd = await request.formData();

--- a/public/_modal.css
+++ b/public/_modal.css
@@ -1,0 +1,15 @@
+/* Minimal modal styles with corporate-gray/black-white aesthetic */
+.odic-modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.45); display: flex; align-items: center; justify-content: center; z-index: 11000; }
+.odic-modal { width: min(720px, 92vw); background: #fff; color: #111; border-radius: 12px; box-shadow: 0 20px 70px rgba(0,0,0,0.3); overflow: hidden; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; }
+.odic-modal__header { padding: 16px 20px; border-bottom: 1px solid rgba(0,0,0,0.08); display: flex; align-items: center; justify-content: space-between; }
+.odic-modal__title { margin: 0; font-size: 18px; font-weight: 600; }
+.odic-modal__close { background: transparent; border: 0; font-size: 18px; cursor: pointer; color: #111; }
+.odic-modal__body { padding: 20px; max-height: min(70vh, 600px); overflow: auto; }
+.odic-modal__footer { padding: 14px 20px; border-top: 1px solid rgba(0,0,0,0.08); display: flex; gap: 8px; justify-content: flex-end; }
+.odic-btn { padding: 8px 14px; border: 0; border-radius: 8px; cursor: pointer; font-weight: 600; }
+.odic-btn--primary { background: #111; color: #fff; }
+.odic-btn--secondary { background: #f2f2f2; color: #111; }
+.odic-input { width: 100%; padding: 10px 12px; border-radius: 8px; border: 1px solid rgba(0,0,0,0.12); background: #fff; color: #111; }
+.odic-select { width: 100%; padding: 10px 12px; border-radius: 8px; border: 1px solid rgba(0,0,0,0.12); background: #fff; color: #111; }
+.odic-field { margin-bottom: 14px; }
+.odic-help { font-size: 12px; color: #555; }

--- a/public/app.js
+++ b/public/app.js
@@ -186,12 +186,24 @@ class ODICFinanceSystem {
             const action=m.querySelector('#odic-action');
 
             const buildImport=()=>{
-              area.innerHTML = '<div class="odic-field"><label>CSV File</label><input type="file" id="odic-file" accept=".csv" class="odic-input" /></div><label class="odic-field"><input type="checkbox" id="odic-dryrun" /> Dry-run (validate only)</label>';
+              area.innerHTML = '<div class="odic-field"><label>CSV File</label><input type="file" id="odic-file" accept=".csv" class="odic-input" /></div><div class="odic-help">Download template: <a id="odic-template-link" href="#" target="_blank" rel="noopener">Select a dataset</a></div><label class="odic-field"><input type="checkbox" id="odic-dryrun" /> Dry-run (validate only)</label>';
             };
             const buildExport=()=>{
               area.innerHTML = '<div class="odic-help">Click Export to download the CSV for the selected dataset.</div>';
             };
             (mode==='Import'?buildImport:buildExport)();
+
+            // Template download link mapping and updater
+            const templateMap = { pos: '/data/po_import_template.csv', invoices: '/data/invoice_import_template.csv', dcs: '/data/dc_import_template.csv' };
+            const updateTemplateLink = () => {
+              const ds = select.value;
+              const a = m.querySelector('#odic-template-link');
+              if (!a) return;
+              const href = templateMap[ds];
+              if (href) { a.href = href; a.textContent = 'Download template'; a.style.display = ''; }
+              else { a.removeAttribute('href'); a.textContent = 'No template available'; a.style.display='none'; }
+            };
+            if (mode === 'Import') { updateTemplateLink(); select.addEventListener('change', updateTemplateLink); }
 
             action.onclick = async ()=>{
               const ds = select.value;

--- a/public/app.js
+++ b/public/app.js
@@ -204,7 +204,7 @@ class ODICFinanceSystem {
               } else {
                 const file=document.getElementById('odic-file').files[0]; if(!file){alert('Please choose a CSV'); return;}
                 const dry=document.getElementById('odic-dryrun').checked;
-                const map={vendors:'/api/vendors/import.csv', instruments:'/api/instruments/import.csv'}; // payments/po/invoice/dc import can be added next
+                const map={vendors:'/api/vendors/import.csv', instruments:'/api/instruments/import.csv', pos:'/api/pos/import.csv', invoices:'/api/invoices/import.csv', dcs:'/api/dcs/import.csv'};
                 const url = base + (map[ds]||''); if(!url){ alert('Import not yet supported for '+ds); return; }
                 const fd=new FormData(); fd.append('file', file);
                 const res=await fetch(url, { method:'POST', headers: Object.assign({}, headers, dry?{'x-dry-run':'1'}:{}), body: fd});

--- a/public/app.js
+++ b/public/app.js
@@ -194,7 +194,7 @@ class ODICFinanceSystem {
             (mode==='Import'?buildImport:buildExport)();
 
             // Template download link mapping and updater
-            const templateMap = { pos: '/data/po_import_template.csv', invoices: '/data/invoice_import_template.csv', dcs: '/data/dc_import_template.csv' };
+            const templateMap = { vendors: '/data/vendors_import_template.csv', instruments: '/data/instruments_import_template.csv', pos: '/data/po_import_template.csv', invoices: '/data/invoice_import_template.csv', dcs: '/data/dc_import_template.csv' };
             const updateTemplateLink = () => {
               const ds = select.value;
               const a = m.querySelector('#odic-template-link');

--- a/public/data/dc_import_template.csv
+++ b/public/data/dc_import_template.csv
@@ -1,0 +1,3 @@
+dc_number,vendor_id,status,items
+DC/2025-26/0001,1,pending,"[{\"sku\":\"HP-LASER-1\",\"qty\":2}]"
+DC/2025-26/0002,2,approved,"[{\"sku\":\"CAB-ETH-5M\",\"qty\":10}]"

--- a/public/data/instruments_import_template.csv
+++ b/public/data/instruments_import_template.csv
@@ -1,0 +1,2 @@
+title,type_name,reference_no,vendor_id,amount,currency,status,issue_date,expiry_date,document_url,notes
+BG/2025-26/0002,Bank Guarantee,BG-0002,1,500000,INR,active,2025-09-15,2026-09-15,https://example.com/bg.pdf,Initial BG

--- a/public/data/inventory_import_template.csv
+++ b/public/data/inventory_import_template.csv
@@ -1,0 +1,3 @@
+item_code,item_name,uom,opening_qty,location,reorder_level,tax_hsn
+ITM-0001,HDMI Cable 1.5m,NOS,100,Main WH,20,8544
+ITM-0002,Printer Toner 12A,NOS,25,Main WH,5,8443

--- a/public/data/invoice_import_template.csv
+++ b/public/data/invoice_import_template.csv
@@ -1,0 +1,3 @@
+invoice_number,vendor_id,amount,status,due_date
+INV/2025-26/0001,1,15000,pending,2025-10-15
+INV/2025-26/0002,2,42500,approved,2025-10-20

--- a/public/data/po_import_template.csv
+++ b/public/data/po_import_template.csv
@@ -1,0 +1,3 @@
+po_number,vendor_id,amount,status
+PO/2025-26/0001,1,25000,pending
+PO/2025-26/0002,2,9999,approved

--- a/public/data/projects_import_template.csv
+++ b/public/data/projects_import_template.csv
@@ -1,0 +1,3 @@
+project_code,project_name,start_date,end_date,budget,manager,cost_center,status
+PRJ-001,Warehouse Expansion,2025-10-01,2026-03-31,2500000,Amit Sharma,CC-OPS,planned
+PRJ-002,ERP Upgrade,2025-11-15,2026-06-30,1800000,Priya Verma,CC-IT,planned

--- a/public/data/transportation_import_template.csv
+++ b/public/data/transportation_import_template.csv
@@ -1,0 +1,3 @@
+shipment_id,mode,carrier,vehicle_no,driver_name,origin,destination,eway_bill_no,eway_valid_till,dispatch_date,expected_delivery
+T-0001,Courier,BlueDart,,,'Noida, UP','Mumbai, MH',,,'2025-10-01','2025-10-04'
+T-0002,OwnFleet,,UP16AB1234,'Ramesh Kumar','Noida, UP','Lucknow, UP','12-3456-7890','2025-10-05','2025-10-02','2025-10-03'

--- a/public/data/vendors_import_template.csv
+++ b/public/data/vendors_import_template.csv
@@ -1,0 +1,2 @@
+company_name,legal_name,gstin,pan,state,state_code,pin_code,business_type,status,rating
+Example Vendor Pvt Ltd,Example Vendor Private Limited,07AADCI9794D1Z8,AADCI9794D,Delhi,07,110002,Service Provider,approved,4.5

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,7 @@
     <title>ODIC International - Vendor Management System (VMS)</title>
     <link rel="stylesheet" href="/style.css">
         <link rel="stylesheet" href="/_fab.css">
+        <link rel="stylesheet" href="/_modal.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <meta name="description" content="ODIC International - Vendor Management System (VMS): Complete PO, Invoice, DC & Vendor Management">

--- a/public/index.html
+++ b/public/index.html
@@ -276,6 +276,22 @@
                     <i class="fas fa-university"></i>
                     <span>Financial Instruments</span>
                 </a>
+                <a href="#" class="nav-item" data-screen="transportation" title="Transportation">
+                    <i class="fas fa-truck"></i>
+                    <span>Transportation</span>
+                </a>
+                <a href="#" class="nav-item" data-screen="projects" title="Projects">
+                    <i class="fas fa-diagram-project"></i>
+                    <span>Projects</span>
+                </a>
+                <a href="#" class="nav-item" data-screen="inventory" title="Inventory">
+                    <i class="fas fa-boxes-stacked"></i>
+                    <span>Inventory</span>
+                </a>
+                <a href="#" class="nav-item" data-screen="b2c" title="B2C (Upcoming)">
+                    <i class="fas fa-store"></i>
+                    <span>B2C</span>
+                </a>
                 <a href="#" class="nav-item" data-screen="settings" title="System Configuration">
                     <i class="fas fa-cog"></i>
                     <span>System Settings</span>
@@ -1695,6 +1711,109 @@
                     </div>
                 </div>
             </div>
+                <!-- Transportation (Upcoming) -->
+                <div id="transportation" class="content-screen">
+                    <div class="content-header">
+                        <div class="page-title">
+                            <h1><i class="fas fa-truck"></i> Transportation</h1>
+                            <p>Courier orchestration, vehicle placement, and e‑Way Bill wizard — enterprise‑grade logistics, built the ODIC way.</p>
+                        </div>
+                        <div class="header-actions">
+                            <a class="btn btn--outline" href="/data/transportation_import_template.csv" download>
+                                <i class="fas fa-download"></i>
+                                CSV Template
+                            </a>
+                            <button class="btn btn--primary" disabled title="Coming soon">Launch Module</button>
+                        </div>
+                    </div>
+                    <div class="feature-placeholder">
+                        <div class="feature-icon"><i class="fas fa-road"></i></div>
+                        <h3>Next‑level Logistics</h3>
+                        <p>Plan routes, assign vehicles, generate compliant e‑Way Bills, and track courier SLAs with audit‑ready telemetry.</p>
+                        <div class="feature-list">
+                            <div class="feature-item"><i class="fas fa-check"></i> Vehicle placement board with smart capacity suggestions</div>
+                            <div class="feature-item"><i class="fas fa-check"></i> e‑Way Bill wizard with validations and document vault</div>
+                            <div class="feature-item"><i class="fas fa-check"></i> Courier integrations, label printing, and SLA tracking</div>
+                            <div class="feature-item"><i class="fas fa-check"></i> Real‑time status updates and delivery proofs</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Projects (Upcoming) -->
+                <div id="projects" class="content-screen">
+                    <div class="content-header">
+                        <div class="page-title">
+                            <h1><i class="fas fa-diagram-project"></i> Projects</h1>
+                            <p>Portfolio, budgets, and execution — budget vs actuals with linked contracts and documents.</p>
+                        </div>
+                        <div class="header-actions">
+                            <a class="btn btn--outline" href="/data/projects_import_template.csv" download>
+                                <i class="fas fa-download"></i>
+                                CSV Template
+                            </a>
+                            <button class="btn btn--primary" disabled title="Coming soon">Launch Module</button>
+                        </div>
+                    </div>
+                    <div class="feature-placeholder">
+                        <div class="feature-icon"><i class="fas fa-chart-pie"></i></div>
+                        <h3>Budget vs Actuals</h3>
+                        <p>Plan, allocate, and monitor project spend with real‑time deviations and alerts.</p>
+                        <div class="feature-list">
+                            <div class="feature-item"><i class="fas fa-check"></i> Cost codes and work‑package tracking</div>
+                            <div class="feature-item"><i class="fas fa-check"></i> Linked POs, invoices, and change orders</div>
+                            <div class="feature-item"><i class="fas fa-check"></i> Document hub for contracts, drawings, and approvals</div>
+                            <div class="feature-item"><i class="fas fa-check"></i> Insights and forecast curves</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Inventory (Upcoming) -->
+                <div id="inventory" class="content-screen">
+                    <div class="content-header">
+                        <div class="page-title">
+                            <h1><i class="fas fa-boxes-stacked"></i> Inventory</h1>
+                            <p>Items, stock, transfers, GRN & issues — accurate, auditable, and lightning‑fast.</p>
+                        </div>
+                        <div class="header-actions">
+                            <a class="btn btn--outline" href="/data/inventory_import_template.csv" download>
+                                <i class="fas fa-download"></i>
+                                CSV Template
+                            </a>
+                            <button class="btn btn--primary" disabled title="Coming soon">Launch Module</button>
+                        </div>
+                    </div>
+                    <div class="feature-placeholder">
+                        <div class="feature-icon"><i class="fas fa-warehouse"></i></div>
+                        <h3>Stock Intelligence</h3>
+                        <p>Item masters, multi‑location stock, bin management, and transfer workflows with approvals.</p>
+                        <div class="feature-list">
+                            <div class="feature-item"><i class="fas fa-check"></i> GRN, issues, and returns with document capture</div>
+                            <div class="feature-item"><i class="fas fa-check"></i> Reorder levels and shortage alerts</div>
+                            <div class="feature-item"><i class="fas fa-check"></i> Serial/batch support (future)</div>
+                            <div class="feature-item"><i class="fas fa-check"></i> CSV import/export with dry‑run</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- B2C (Roadmap) -->
+                <div id="b2c" class="content-screen">
+                    <div class="content-header">
+                        <div class="page-title">
+                            <h1><i class="fas fa-store"></i> B2C (Upcoming)</h1>
+                            <p>Consumer workflows — discovery, checkout, settlements. Planning stage only; no implementation yet.</p>
+                        </div>
+                        <div class="header-actions">
+                            <button class="btn btn--outline" disabled>Roadmap</button>
+                            <button class="btn btn--primary" disabled>Coming Soon</button>
+                        </div>
+                    </div>
+                    <div class="feature-placeholder">
+                        <div class="feature-icon"><i class="fas fa-rocket"></i></div>
+                        <h3>Vision</h3>
+                        <p>Seamless consumer experiences integrated with ODIC’s financial backbone. Launching big — polished, secure, and scalable.</p>
+                    </div>
+                </div>
+
         <!-- Universal FABs -->
             <div class="fab-container" id="fabContainer" style="display:none">
                 <div style="position:relative">


### PR DESCRIPTION
- Adds Download template link in Import modal that switches with dataset selection
- Templates added:
  - public/data/vendors_import_template.csv
  - public/data/instruments_import_template.csv
  - public/data/po_import_template.csv
  - public/data/invoice_import_template.csv
  - public/data/dc_import_template.csv
- Verified mapping to API endpoints:
  - Vendors → /api/vendors/import.csv (upsert by gstin, partial unique)
  - Instruments → /api/instruments/import.csv (title required; reference_no upsert if present)
  - POs → /api/pos/import.csv (upsert by po_number)
  - Invoices → /api/invoices/import.csv (upsert by invoice_number)
  - DCs → /api/dcs/import.csv (upsert by dc_number)
- No server code changes beyond previous approvals.

Testing summary: smoke tests OK for modal UI link switching and export/import endpoints exist in worker.
